### PR TITLE
Add first and last pagination controls

### DIFF
--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -30,7 +30,7 @@ const BlogPost = ({ node }) => {
 
 class IndexPage extends React.Component {
   render() {
-    const { nextPath, prevPath, pageID } = this.props.pageContext;
+    const { nextPath, prevPath, firstPath, lastPath, pageID } = this.props.pageContext;
     const posts = this.props.data.allContentfulPost.edges;
 
     console.log(this.props.pageContext);
@@ -45,6 +45,31 @@ class IndexPage extends React.Component {
           </ul>
 
           <div className="flex justify-center cabin b ma4">
+            <div className="ph2">
+              {firstPath && (
+                <Link to={firstPath}>
+                  <svg
+                    className="w1"
+                    data-icon={"chevronLeft"}
+                    viewBox={"0 0 32 32"}
+                    style={{ fill: `currentcolor` }}
+                  >
+                    <title>chevronLeft icon</title>
+                    <path d="M20 1 L24 5 L14 16 L24 27 L20 31 L6 16 z" />
+                  </svg>
+                  <svg
+                    className="w1"
+                    data-icon={"chevronLeft"}
+                    viewBox={"0 0 32 32"}
+                    style={{ fill: `currentcolor` }}
+                  >
+                    <title>chevronLeft icon</title>
+                    <path d="M20 1 L24 5 L14 16 L24 27 L20 31 L6 16 z" />
+                  </svg>
+                </Link>
+              )}
+            </div>
+
             <div className="ph2">
               {prevPath && (
                 <Link to={prevPath}>
@@ -68,6 +93,31 @@ class IndexPage extends React.Component {
               {nextPath && (
                 <Link to={nextPath}>
                   <span className="ph2 f5 f4-ns f4-m v-btm">Next</span>
+                  <svg
+                    className="w1"
+                    data-icon={"chevronRight"}
+                    viewBox={"0 0 32 32"}
+                    style={{ fill: `currentcolor` }}
+                  >
+                    <title>chevronRight icon</title>
+                    <path d="M12 1 L26 16 L12 31 L8 27 L18 16 L8 5 z" />
+                  </svg>
+                </Link>
+              )}
+            </div>
+
+            <div className="ph2">
+              {lastPath && (
+                <Link to={lastPath}>
+                  <svg
+                    className="w1"
+                    data-icon={"chevronRight"}
+                    viewBox={"0 0 32 32"}
+                    style={{ fill: `currentcolor` }}
+                  >
+                    <title>chevronRight icon</title>
+                    <path d="M12 1 L26 16 L12 31 L8 27 L18 16 L8 5 z" />
+                  </svg>
                   <svg
                     className="w1"
                     data-icon={"chevronRight"}

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -39,8 +39,12 @@ module.exports = (
         totalPages: pageCount,
         // The path to the previous paginated page (or an empty string)
         prevPath: paginationPath(basePath, index - 1, pageCount),
+        // The path to the first paginated page (or an empty string)
+        firstPath: paginationPath(basePath, 0, pageCount),
         // The path to the next paginated page (or an empty string)
         nextPath: paginationPath(basePath, index + 1, pageCount),
+        // The path to the last paginated page (or an empty string)
+        lastPath: paginationPath(basePath, pageCount - 1, pageCount),
         // Current page ID for displaying between chevrons
         pageID: index + 1
       }

--- a/utils/paginate.test.js
+++ b/utils/paginate.test.js
@@ -15,8 +15,10 @@ test('stops generating a next page link on the final paginated page', () => {
   );
 
   assert.equal(createdPages.length, 16);
+  assert.equal(createdPages[0].context.firstPath, '/');
   assert.equal(createdPages[0].context.nextPath, '/page/2');
   assert.equal(createdPages[14].context.nextPath, '/page/16');
   assert.equal(createdPages[15].context.pageID, 16);
+  assert.equal(createdPages[15].context.lastPath, '/page/16');
   assert.equal(createdPages[15].context.nextPath, '');
 });


### PR DESCRIPTION
## Summary

Add first and last pagination controls to the blog index so users can jump to the start or end of the paginated list.

## What changed

- Added chevron-based first and last page links to the blog index paginator.
- Exposed first/last page paths from the pagination helper.
- Added regression coverage for the pagination helper.

## Issue

Fixes #77